### PR TITLE
:wrench: Change user

### DIFF
--- a/.github/workflows/major-release-tag.yml
+++ b/.github/workflows/major-release-tag.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
           VERSION=${GITHUB_REF#refs/tags/}
           MAJOR=${VERSION%%.*}
-          git config --global user.name 'IamPekka058'
-          git config --global user.email '59747867+IamPekka058@users.noreply.github.com'
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -fa "${MAJOR}" -m 'Update major version tag'
           git push origin "${MAJOR}" --force


### PR DESCRIPTION
This pull request updates the Git configuration in the `.github/workflows/major-release-tag.yml` file to use the `github-actions[bot]` account instead of a personal account for tagging operations in the CI workflow.

CI workflow update:

* [`.github/workflows/major-release-tag.yml`](diffhunk://#diff-795a65b943556d553e886118695447d90fb4b97dc6117b9c5b74d77a69ed77fbL21-R22): Changed the `git config` commands to set the user name and email to `github-actions[bot]` for tagging operations